### PR TITLE
Verify that formatter arguments are not None

### DIFF
--- a/pygetty/__init__.py
+++ b/pygetty/__init__.py
@@ -2,4 +2,4 @@ from __future__ import unicode_literals
 
 __doc__ = 'Wrapper for Getty v3 API'
 __author__ = 'Josh Klar <josh@lumen5.com>'
-__version__ = '1.1.2'
+__version__ = '1.1.3'

--- a/pygetty/formatters.py
+++ b/pygetty/formatters.py
@@ -8,10 +8,10 @@ MASTERY_DIMENSIONS_REGEX = re.compile(r'(?P<width>[0-9]+)x(?P<height>[0-9]+)')
 
 
 def format_image(image):
-    if 'date_created' in image:
+    if image.get('date_created') is not None:
         image['date_created'] = pendulum.parse(image['date_created'])
 
-    if 'keywords' in image:
+    if image.get('keywords') is not None:
         image['raw_keywords'] = image['keywords']
         image['keywords'] = [kw['text'] for kw in image['keywords']]
 
@@ -19,10 +19,10 @@ def format_image(image):
 
 
 def format_video(video):
-    if 'date_created' in video:
+    if video.get('date_created') is not None:
         video['date_created'] = pendulum.parse(video['date_created'])
 
-    if 'clip_length' in video:
+    if video.get('clip_length') is not None:
         cl = [int(x) for x in video['clip_length'].split(':')]
         video['clip_length'] = pendulum.duration(
             days=cl[0],
@@ -31,11 +31,11 @@ def format_video(video):
             seconds=cl[3],
         )
 
-    if 'keywords' in video:
+    if video.get('keywords') is not None:
         video['raw_keywords'] = video['keywords']
         video['keywords'] = [kw['text'] for kw in video['keywords']]
 
-    if 'mastered_to' in video:
+    if video.get('mastered_to') is not None:
         video['parsed_dimensions'] = {
             k: int(v)
             for k, v in re.search(


### PR DESCRIPTION
Sometimes Getty assets will include an expected key in a search result,
but it'll be `None` (the notable case here was in
`video['clip_length']`). This change verifies there's actually a value
to operate on.