### PR TITLE
Search: Respect total result field rather than running until HTTP 400

### DIFF
--- a/pygetty/__init__.py
+++ b/pygetty/__init__.py
@@ -2,4 +2,4 @@ from __future__ import unicode_literals
 
 __doc__ = 'Wrapper for Getty v3 API'
 __author__ = 'Josh Klar <josh@lumen5.com>'
-__version__ = '1.1.5'
+__version__ = '1.1.6'


### PR DESCRIPTION
This was originally implemented this way because of glitches in the
total result field (where it'd constantly return 0), but these seem to
be gone now. We were silently burying the exception so I never thought
to actually, ya know, fix it. Oops.